### PR TITLE
For anyone trying to push behind a firewall or proxy...

### DIFF
--- a/PusherRESTDotNet/PusherProvider.cs
+++ b/PusherRESTDotNet/PusherProvider.cs
@@ -14,9 +14,10 @@ namespace PusherRESTDotNet
 		private readonly string _applicationId;
 		private readonly string _applicationKey;
 		private readonly string _applicationSecret;
-        private PusherAuthenticationHelper _authHelper;
+        private readonly PusherAuthenticationHelper _authHelper;
+	    private readonly IWebProxy _webProxy;
 
-		public PusherProvider(string applicationId, string applicationKey, string applicationSecret)
+		public PusherProvider(string applicationId, string applicationKey, string applicationSecret, IWebProxy webProxy = null)
 		{
 			if (String.IsNullOrEmpty(applicationId))
 				throw new ArgumentNullException("applicationId");
@@ -28,7 +29,7 @@ namespace PusherRESTDotNet
 			_applicationSecret = applicationSecret;
 			_applicationKey = applicationKey;
 			_applicationId = applicationId;
-
+		    _webProxy = webProxy;
             _authHelper = new PusherAuthenticationHelper(_applicationId, _applicationKey, _applicationSecret);
 		}
 
@@ -46,6 +47,10 @@ namespace PusherRESTDotNet
 
 		    using(var client = new WebClient())
 		    {
+                if(_webProxy != null)
+                {
+                    client.Proxy = _webProxy;
+                }
 		        client.Encoding = Encoding.UTF8;
 		        client.UploadString(requestUrl, request.JsonData);
 		    }


### PR DESCRIPTION
Hey, I needed to start pushing messages behind a corporate firewall, and noticed there was no way to get around the proxy in the current implementation.  This commit is a simple, un-unit-tested way of setting the proxy.  The ctor argument is optional so it wouldn't change anyone's current functionality.

Unfortunately, given the current structure, it's pretty impossible to write a unit test to validate that the web client's proxy is set with the provided argument.  Not sure what the direction is for those tests, but I'd be happy to volunteer a little time if you were willing to restructure your code a little bit to provide some tests re: the collaboration between PusherProvider and whatever is making the actual HTTP request.
